### PR TITLE
Extra \n at end of line in raw string literal.

### DIFF
--- a/src/gini/cmd/gini/usage.go
+++ b/src/gini/cmd/gini/usage.go
@@ -3,7 +3,7 @@
 
 package main
 
-var usage = `%s usage: %s <input> <input> <input> ...\n
+var usage = `%s usage: %s <input> <input> <input> ...
 %s reads dimacs cnf or icnf inputs and tries to solve them. The inputs
 may be gzipped or bzip2ed.
 


### PR DESCRIPTION
The user is not expected to type \n ... I guess?