### PR TITLE
activation lit support 

### DIFF
--- a/gini.go
+++ b/gini.go
@@ -204,3 +204,19 @@ func (g *Gini) Untest() int {
 func (g *Gini) Reasons(dst []z.Lit, m z.Lit) []z.Lit {
 	return g.xo.Reasons(dst, m)
 }
+
+// Create a clause from the last (non 0-terminated, non-empty) sequence of Adds and
+// `m.Not()`.  Activate panics if the last sequence of Adds since Add(0) is empty.
+// Additionally, in this case subsequent behavior of `g` is undefined.
+//
+// To active the clause, assume `m`.
+func (g *Gini) Activate() (m z.Lit) {
+	return g.xo.Activate()
+}
+
+// Deactivate deactivates a literal as returned by Activate.  Deactivation
+// frees the literal for future Activations and removes all clauses, including
+// learned clauses, which contain `m.Not()`.
+func (g *Gini) Deactivate(m z.Lit) {
+	g.xo.Deactivate(m)
+}

--- a/gini.go
+++ b/gini.go
@@ -69,7 +69,6 @@ func NewVc(vCapHint, cCapHint int) *Gini {
 //  2. Control mechanisms for Solve's resulting from GoSolve() so the
 //     copied gini can make its own calls to GoSolve() (or Solve()) without
 //     affecting the original.
-//  3. Any CnfSimp which has been set
 func (g *Gini) Copy() *Gini {
 	other := &Gini{
 		xo: g.xo.Copy()}
@@ -129,20 +128,6 @@ func (g *Gini) Solve() int {
 // solving goroutine, a goroutine which calls Solve()
 func (g *Gini) GoSolve() inter.Solve {
 	return g.xo.GoSolve()
-}
-
-// Simplify implements inter.Simplifier.  By default,
-// Simplify does nothing and returns 0.  To make Simplify
-// do some work, use SetCnfSimp().
-func (g *Gini) Simplify() int {
-	return g.xo.Simplify()
-}
-
-// SetCnfSimp sets the current simplifier implementation
-// to `s`.  If `s` is nil (and by default) the CnfSimp
-// associated with `g` is nil.
-func (g *Gini) SetCnfSimp(s inter.CnfSimp) {
-	g.xo.SetCnfSimp(s)
 }
 
 // Value returns the truth value of the literal m.

--- a/gini.go
+++ b/gini.go
@@ -207,9 +207,30 @@ func (g *Gini) Reasons(dst []z.Lit, m z.Lit) []z.Lit {
 
 // Create a clause from the last (non 0-terminated, non-empty) sequence of Adds and
 // `m.Not()`.  Activate panics if the last sequence of Adds since Add(0) is empty.
-// Additionally, in this case subsequent behavior of `g` is undefined.
+// Additionally, in this case subsequent behavior of `g` is undefined.  The caller
+// should verify a clause is not empty using `g.Value(m)` for all literals in in
+// the clause to activate.
 //
 // To active the clause, assume `m`.
+//
+// Example:
+//
+//  if g.Value(a) != false || g.Value(b) != false {
+//    g.Add(a)
+//    g.Add(b)
+//    m := g.Activate()  // don't call g.Add(0).
+//    g.Assume(m) // now the clause (a + b)  is active
+//    if g.Solve() == 1 {
+//       // do something
+//    }
+//    // now the clause (a+b) is not active.
+//    g.Deactivate(m)
+//    // now `m` can be re-used and the solver can ignore
+//    // clauses with `m`.
+//  }
+//
+// Activation of all clauses can be used in conjunction with cardinality constraints
+// to easily create a MAXSAT solver.
 func (g *Gini) Activate() (m z.Lit) {
 	return g.xo.Activate()
 }

--- a/gini.go
+++ b/gini.go
@@ -69,6 +69,7 @@ func NewVc(vCapHint, cCapHint int) *Gini {
 //  2. Control mechanisms for Solve's resulting from GoSolve() so the
 //     copied gini can make its own calls to GoSolve() (or Solve()) without
 //     affecting the original.
+//  3. Any CnfSimp which has been set
 func (g *Gini) Copy() *Gini {
 	other := &Gini{
 		xo: g.xo.Copy()}
@@ -125,6 +126,20 @@ func (g *Gini) Solve() int {
 // solving goroutine, a goroutine which calls Solve()
 func (g *Gini) GoSolve() inter.Solve {
 	return g.xo.GoSolve()
+}
+
+// Simplify implements inter.Simplifier.  By default,
+// Simplify does nothing and returns 0.  To make Simplify
+// do some work, use SetCnfSimp().
+func (g *Gini) Simplify() int {
+	return g.xo.Simplify()
+}
+
+// SetCnfSimp sets the current simplifier implementation
+// to `s`.  If `s` is nil (and by default) the CnfSimp
+// associated with `g` is nil.
+func (g *Gini) SetCnfSimp(s inter.CnfSimp) {
+	g.xo.SetCnfSimp(s)
 }
 
 // Value returns the truth value of the literal m.

--- a/gini.go
+++ b/gini.go
@@ -260,6 +260,14 @@ func (g *Gini) ActivateWith(act z.Lit) {
 	g.xo.ActivateWith(act)
 }
 
+// ActivationLit returns a new literal to be used with ActivateWith().
+//
+// ActivationLit is an unsupported operation under a test scope and will
+// panic if called under a test scope.
+func (g *Gini) ActivationLit() z.Lit {
+	return g.xo.ActivationLit()
+}
+
 // Deactivate deactivates a literal as returned by Activate.  Deactivation
 // frees the literal for future Activations and removes all clauses, including
 // learned clauses, which contain `m.Not()`.

--- a/gini_test.go
+++ b/gini_test.go
@@ -4,7 +4,6 @@
 package gini
 
 import (
-	"math/rand"
 	"testing"
 	"time"
 
@@ -59,96 +58,5 @@ func TestGiniAsync(t *testing.T) {
 	if sDur > timeout+margin {
 		// CI builders don't like this and have unreasonable values.
 		t.Logf("cancelled late. %s > %s", sDur, timeout)
-	}
-}
-
-type dummySimp struct {
-	toRm   []z.C
-	toKeep []z.C
-	tst    *testing.T
-}
-
-func (d *dummySimp) OnAdded(c z.C, ms []z.Lit) {
-	for _, m := range ms {
-		if m.Var() == 1024 {
-			d.toRm = append(d.toRm, c)
-			return
-		}
-	}
-	d.toKeep = append(d.toKeep, c)
-}
-
-func (d *dummySimp) CRemap(cm map[z.C]z.C) {
-	for i, c := range d.toKeep {
-		n, ok := cm[c]
-		if !ok {
-			continue
-		}
-		if n == 0 {
-			d.tst.Errorf("got CNull on remap")
-			continue
-		}
-		d.toKeep[i] = n
-	}
-}
-
-func (d *dummySimp) Simplify(rmSpace []z.C) (status int, rms []z.C) {
-	rms = rmSpace
-	rms = append(rms, d.toRm...)
-	d.toRm = d.toRm[:0]
-	status = 0
-	return
-}
-
-func TestCnfSimp(t *testing.T) {
-	// we do pure lit on 1024, and create a formula with >2048 clauses
-	// containing 1024 together with a 64 variable random 3cnf near the
-	// cutoff of sat/unsat equal probability
-	for n := 0; n < 32; n++ {
-		s0, s1 := New(), New()
-		s0.SetCnfSimp(&dummySimp{tst: t})
-		pure := z.Var(1024).Pos()
-		with := z.Var(1025).Pos()
-		for i := 0; i < 2049; i++ { // 2049 because 2048 is the limit to cause lit removal.
-			// not unit so they will all add
-			s0.Add(pure)
-			s0.Add(with)
-			s0.Add(0)
-			s1.Add(pure)
-			s1.Add(with)
-			s1.Add(0)
-		}
-		for i := 0; i < 270; i++ {
-			va, vb, vc := z.Var(rand.Intn(64)+1), z.Var(rand.Intn(64)+1), z.Var(rand.Intn(64)+1)
-			ma := va.Pos()
-			if rand.Intn(2) == 1 {
-				ma = ma.Not()
-			}
-			mb := vb.Pos()
-			if rand.Intn(2) == 1 {
-				mb = mb.Not()
-			}
-			mc := vc.Pos()
-			if rand.Intn(2) == 1 {
-				mc = mc.Not()
-			}
-			s0.Add(ma)
-			s0.Add(mb)
-			s0.Add(mc)
-			s0.Add(0)
-
-			s1.Add(ma)
-			s1.Add(mb)
-			s1.Add(mc)
-			s1.Add(0)
-		}
-		if n := s0.Simplify(); n != 0 {
-			t.Errorf("simplify gave %d\n", n)
-		}
-		a, b := s0.Solve(), s1.Solve()
-		if a != b {
-			t.Errorf("something went wrong %d,%d\n", a, b)
-		}
-		//t.Logf("%d ?= %d\n", a, b)
 	}
 }

--- a/gini_test.go
+++ b/gini_test.go
@@ -4,6 +4,7 @@
 package gini
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
@@ -58,5 +59,96 @@ func TestGiniAsync(t *testing.T) {
 	if sDur > timeout+margin {
 		// CI builders don't like this and have unreasonable values.
 		t.Logf("cancelled late. %s > %s", sDur, timeout)
+	}
+}
+
+type dummySimp struct {
+	toRm   []z.C
+	toKeep []z.C
+	tst    *testing.T
+}
+
+func (d *dummySimp) OnAdded(c z.C, ms []z.Lit) {
+	for _, m := range ms {
+		if m.Var() == 1024 {
+			d.toRm = append(d.toRm, c)
+			return
+		}
+	}
+	d.toKeep = append(d.toKeep, c)
+}
+
+func (d *dummySimp) CRemap(cm map[z.C]z.C) {
+	for i, c := range d.toKeep {
+		n, ok := cm[c]
+		if !ok {
+			continue
+		}
+		if n == 0 {
+			d.tst.Errorf("got CNull on remap")
+			continue
+		}
+		d.toKeep[i] = n
+	}
+}
+
+func (d *dummySimp) Simplify(rmSpace []z.C) (status int, rms []z.C) {
+	rms = rmSpace
+	rms = append(rms, d.toRm...)
+	d.toRm = d.toRm[:0]
+	status = 0
+	return
+}
+
+func TestCnfSimp(t *testing.T) {
+	// we do pure lit on 1024, and create a formula with >2048 clauses
+	// containing 1024 together with a 64 variable random 3cnf near the
+	// cutoff of sat/unsat equal probability
+	for n := 0; n < 32; n++ {
+		s0, s1 := New(), New()
+		s0.SetCnfSimp(&dummySimp{tst: t})
+		pure := z.Var(1024).Pos()
+		with := z.Var(1025).Pos()
+		for i := 0; i < 2049; i++ { // 2049 because 2048 is the limit to cause lit removal.
+			// not unit so they will all add
+			s0.Add(pure)
+			s0.Add(with)
+			s0.Add(0)
+			s1.Add(pure)
+			s1.Add(with)
+			s1.Add(0)
+		}
+		for i := 0; i < 270; i++ {
+			va, vb, vc := z.Var(rand.Intn(64)+1), z.Var(rand.Intn(64)+1), z.Var(rand.Intn(64)+1)
+			ma := va.Pos()
+			if rand.Intn(2) == 1 {
+				ma = ma.Not()
+			}
+			mb := vb.Pos()
+			if rand.Intn(2) == 1 {
+				mb = mb.Not()
+			}
+			mc := vc.Pos()
+			if rand.Intn(2) == 1 {
+				mc = mc.Not()
+			}
+			s0.Add(ma)
+			s0.Add(mb)
+			s0.Add(mc)
+			s0.Add(0)
+
+			s1.Add(ma)
+			s1.Add(mb)
+			s1.Add(mc)
+			s1.Add(0)
+		}
+		if n := s0.Simplify(); n != 0 {
+			t.Errorf("simplify gave %d\n", n)
+		}
+		a, b := s0.Solve(), s1.Solve()
+		if a != b {
+			t.Errorf("something went wrong %d,%d\n", a, b)
+		}
+		t.Logf("%d ?= %d\n", a, b)
 	}
 }

--- a/gini_test.go
+++ b/gini_test.go
@@ -149,6 +149,6 @@ func TestCnfSimp(t *testing.T) {
 		if a != b {
 			t.Errorf("something went wrong %d,%d\n", a, b)
 		}
-		t.Logf("%d ?= %d\n", a, b)
+		//t.Logf("%d ?= %d\n", a, b)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/irifrance/gini
+
+require github.com/irifrance/reach v0.0.0-20181118144909-1ff030ec0e08 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/irifrance/gini
-
-require github.com/irifrance/reach v0.0.0-20181118144909-1ff030ec0e08 // indirect

--- a/inter/s.go
+++ b/inter/s.go
@@ -228,3 +228,18 @@ type Simplifier interface {
 	// and returns the status after removing the requested claues.
 	Simplify() int
 }
+
+// Activatable provides support for recyclable activation literals
+type Activatable interface {
+	// Activate should be called in place of Add(0) to activate a
+	// clause.  Activate returns the activation literal, which, if assigned
+	// activates the last added clause.
+	//
+	// If the last clause is empty, then Activate panics.  The caller
+	// should only activate non-empty clauses.
+	Activate() z.Lit
+
+	// Deactivate deactivates an activation literal as returned by
+	// Activate
+	Deactivate(m z.Lit)
+}

--- a/inter/s.go
+++ b/inter/s.go
@@ -159,80 +159,10 @@ type Sc interface {
 	Stop()
 }
 
-// CnfSimp provides an interface for clause based
-// simplifications.
-//
-type CnfSimp interface {
-	// OnAdded is called with an identifier `c` and
-	// a set of literals `ms` whenever `ms` is added.
-	// Since `ms` is added, it is known to be non-tautological,
-	// have no duplicate literals, and no literals known to be
-	// true or false under all previously added clauses.
-	//
-	// Also, no learnt clauses are passed to OnAdded.
-	OnAdded(c z.C, ms []z.Lit)
-
-	// CRemap is called by the solver whenever it undergoes
-	// clause compaction (which in turn happens sometimes
-	// during clause garbage collection).  Since z.C values
-	// are ephemeral, they may change.  CRemap gives provides
-	// CnfSimp implementations with the changed values.
-	//
-	// When CRemap is called, the CnfSimp implementation should
-	// replace every reference `a` to a z.C which is a key in `cm`
-	// with the corresponding value in `cm`.  Every reference
-	// which is not a key maps to itself. Every removed reference
-	// maps to 0.  However, the removed references are those
-	// supplied from the last call to Simplify(), so this info
-	// is not strictly necessary.
-	CRemap(cm map[z.C]z.C)
-
-	// Simplify does preprocessing on added clauses.
-	//
-	// Simplify returns status like Solve (1:sat, -1:unsat, 0:unknown).
-	//
-	// Simplify should populate `rms` with clauses to be removed once the
-	// simplification is done, attempting to use `rmSpace` if possible to house
-	// the ids of clauses to be removed.  Once Simplify returns, CnfSimp
-	// implementation should no longer reference any z.C in rms until or if they
-	// are provided again via OnAdded.
-	//
-	// Adding clauses works as follows. If a solver `s` implements Simplify, and
-	// has a CnfSimp associated with it, then it calls `CnfSimp.Simplify` to
-	// implement s.Simplify. `Cnf.Simplify` may then call `s.Add` like normal.
-	// When a clause is successfully added, `s.Add` will then call `Cnf.OnAdded`.
-	//
-	// This convoluted way of dealing with adding and removing clauses allows a
-	// solver to store and manipulate clauses independently of simplifications.
-	// Since the solvers clause representation can quite complex, subtle and
-	// optimised, this interface is in fact much easier than working within most
-	// solvers, including xo.
-	//
-	// Simplify must retain logical equivalence, since it does not take into
-	// account learned clauses. However, Simplify may add or eliminate variables.
-	// If variables are added, then eliminated them with exists-quantifier
-	// elimination should retain logical equivalence.
-	Simplify(rmSpace []z.C) (status int, rms []z.C)
-}
-
-// Simplifier is a facet of a Solver for simplifications.
-type Simplifier interface {
-	// See CnfSimp
-	SetCnfSimp(cnfSimp CnfSimp)
-
-	// Simplify returns 1: if the result is sat, -1 if the result
-	// is unsat, and 0 if unknown.
-	//
-	// Simplify returns 0 and does nothing SetCnfSimp has not been called
-	// with a non-nil argument.  Otherwise, Simplify calls cnfSimp.Simplify
-	// and returns the status after removing the requested claues.
-	Simplify() int
-}
-
 // Activatable provides support for recyclable activation literals
 //
 // Caveats: activation clauses must not be empty under unit propagtion
-// at level 0.  The caller should ensure this using Value().
+// at level 0.  The caller should ensure this by construction.
 type Activatable interface {
 	// Activate should be called in place of Add(0) to activate a
 	// clause.  Activate returns the activation literal, which, if assigned

--- a/inter/s.go
+++ b/inter/s.go
@@ -230,16 +230,25 @@ type Simplifier interface {
 }
 
 // Activatable provides support for recyclable activation literals
+//
+// Caveats: activation clauses must not be empty under unit propagtion
+// at level 0.  The caller should ensure this using Value().
 type Activatable interface {
 	// Activate should be called in place of Add(0) to activate a
 	// clause.  Activate returns the activation literal, which, if assigned
 	// activates the last added clause.
 	//
 	// If the last clause is empty, then Activate panics.  The caller
-	// should only activate non-empty clauses.
+	// should only activate non-empty clauses.  Note that in incremental
+	// settings, one usually has to verify whether or not a clause is
+	// empty.
+	//
+	// like `Add()`, Activate should only be called at decision level 0.
 	Activate() z.Lit
 
 	// Deactivate deactivates an activation literal as returned by
-	// Activate
+	// Activate.
+	//
+	// like `Add()`, Deactivate should only be called at decision level 0.
 	Deactivate(m z.Lit)
 }

--- a/inter/s.go
+++ b/inter/s.go
@@ -253,6 +253,11 @@ type Activatable interface {
 	// ActivateWith causes them to be recycled.
 	ActivateWith(act z.Lit)
 
+	// ActivationLit returns a literal to be used with ActivateWith.
+	// As all other Activation related methods, ActivationLit is
+	// not supported under test scopes.
+	ActivationLit() z.Lit
+
 	// Deactivate deactivates an activation literal as returned by
 	// Activate.
 	//

--- a/internal/xo/active.go
+++ b/internal/xo/active.go
@@ -44,7 +44,7 @@ func (a *Active) ActivateWith(act z.Lit, s *S) {
 	ms := a.Ms
 	ms = s.Cdb.Lits(loc, ms)
 	is := a.IsActive
-	for _, m := range a.Ms {
+	for _, m := range ms {
 		mv := m.Var()
 		if !is[mv] {
 			continue
@@ -54,7 +54,6 @@ func (a *Active) ActivateWith(act z.Lit, s *S) {
 		}
 		a.Occs[mv] = append(a.Occs[mv], loc)
 	}
-	a.Occs[act.Var()] = append(a.Occs[act.Var()], loc)
 	a.Ms = ms[:0]
 }
 
@@ -74,12 +73,12 @@ func (a *Active) CRemap(rlm map[z.C]z.C) {
 		j := 0
 		for _, c := range sl {
 			d, ok := rlm[c]
-			if d == CNull {
-				continue
-			}
 			if !ok {
 				sl[j] = c
 				j++
+				continue
+			}
+			if d == CNull {
 				continue
 			}
 			sl[j] = d

--- a/internal/xo/active.go
+++ b/internal/xo/active.go
@@ -1,0 +1,95 @@
+package xo
+
+import "github.com/irifrance/gini/z"
+
+type Active struct {
+	Free     []z.Lit
+	Occs     [][]z.C
+	IsActive []bool
+}
+
+func newActive(vcap int) *Active {
+	return &Active{
+		Occs:     make([][]z.C, vcap),
+		IsActive: make([]bool, vcap)}
+}
+
+func (a *Active) Activate(s *S) z.Lit {
+	var act z.Lit = z.LitNull
+	n := len(a.Free)
+
+	if n != 0 {
+		act = a.Free[n-1]
+		a.Free = a.Free[:n-1]
+	} else {
+		act = s.Lit()
+	}
+	a.IsActive[act.Var()] = true
+	s.Add(act.Not())
+
+	loc, u := s.Cdb.Add(0)
+	if u != z.LitNull {
+		panic("activated empty clause")
+	}
+
+	// add occ
+	if loc != CInf {
+		a.Occs[act.Var()] = []z.C{loc}
+	}
+	return act
+}
+
+func (a *Active) Deactivate(cdb *Cdb, m z.Lit) {
+	mv := m.Var()
+	m = mv.Pos()
+	sl := a.Occs[mv]
+	a.Occs[mv] = nil
+	cdb.Remove(sl...) // this might trigger CRemap below, so we update occs first.
+	a.Free = append(a.Free, m)
+	a.IsActive[mv] = false
+}
+
+func (a *Active) CRemap(rlm map[z.C]z.C) {
+	for i := range a.Occs {
+		sl := a.Occs[i]
+		j := 0
+		for _, c := range sl {
+			d, ok := rlm[c]
+			if d == CNull {
+				continue
+			}
+			if !ok {
+				sl[j] = c
+				j++
+				continue
+			}
+			sl[j] = d
+			j++
+		}
+		a.Occs[i] = sl[:j]
+	}
+}
+
+func (a *Active) growToVar(u z.Var) {
+	w := u + 1
+	oc := make([][]z.C, w)
+	copy(oc, a.Occs)
+	a.Occs = oc
+
+	ia := make([]bool, w)
+	copy(ia, a.IsActive)
+	a.IsActive = ia
+}
+
+func (a *Active) Copy() *Active {
+	res := &Active{
+		Occs:     make([][]z.C, len(a.Occs), cap(a.Occs)),
+		IsActive: make([]bool, len(a.IsActive), cap(a.IsActive))}
+	copy(res.IsActive, a.IsActive)
+	for i, asl := range a.Occs {
+		rsl := make([]z.C, len(asl), cap(asl))
+		copy(rsl, asl)
+		res.Occs[i] = rsl
+	}
+	return res
+}

--- a/internal/xo/active.go
+++ b/internal/xo/active.go
@@ -68,8 +68,14 @@ func (a *Active) Deactivate(cdb *Cdb, m z.Lit) {
 }
 
 func (a *Active) CRemap(rlm map[z.C]z.C) {
+	if len(rlm) == 0 {
+		return
+	}
 	for i := range a.Occs {
 		sl := a.Occs[i]
+		if len(sl) == 0 {
+			continue
+		}
 		j := 0
 		for _, c := range sl {
 			d, ok := rlm[c]

--- a/internal/xo/active.go
+++ b/internal/xo/active.go
@@ -14,29 +14,29 @@ func newActive(vcap int) *Active {
 		IsActive: make([]bool, vcap)}
 }
 
-func (a *Active) Activate(s *S) z.Lit {
-	var act z.Lit = z.LitNull
+func (a *Active) Lit(s *S) z.Lit {
 	n := len(a.Free)
-
+	var act z.Lit
 	if n != 0 {
 		act = a.Free[n-1]
 		a.Free = a.Free[:n-1]
 	} else {
 		act = s.Lit()
 	}
+	return act
+}
+
+func (a *Active) ActivateWith(act z.Lit, s *S) {
 	a.IsActive[act.Var()] = true
 	s.Add(act.Not())
-
 	loc, u := s.Cdb.Add(0)
 	if u != z.LitNull {
 		panic("activated empty clause")
 	}
-
 	// add occ
 	if loc != CInf {
 		a.Occs[act.Var()] = []z.C{loc}
 	}
-	return act
 }
 
 func (a *Active) Deactivate(cdb *Cdb, m z.Lit) {
@@ -83,9 +83,11 @@ func (a *Active) growToVar(u z.Var) {
 
 func (a *Active) Copy() *Active {
 	res := &Active{
+		Free:     make([]z.Lit, len(a.Free), cap(a.Free)),
 		Occs:     make([][]z.C, len(a.Occs), cap(a.Occs)),
 		IsActive: make([]bool, len(a.IsActive), cap(a.IsActive))}
 	copy(res.IsActive, a.IsActive)
+	copy(res.Free, a.Free)
 	for i, asl := range a.Occs {
 		rsl := make([]z.C, len(asl), cap(asl))
 		copy(rsl, asl)

--- a/internal/xo/active_test.go
+++ b/internal/xo/active_test.go
@@ -26,6 +26,8 @@ func TestActive3(t *testing.T) {
 	}
 	s1 := s0.Copy()
 	NCs := N*5 - M
+	// since hard 3cnfs fall nearish nclauses = 4*nvars, we'll expect to see
+	// a variety of results and runtimes.
 	Cs := make([]z.Lit, 0, NCs*3)
 	acts0 := make([]z.Lit, NCs)
 	acts1 := make([]z.Lit, NCs)
@@ -47,6 +49,7 @@ func TestActive3(t *testing.T) {
 		Cs = append(Cs, m, n, o)
 	}
 	// compare assumptions with activations/de-activations
+	// under many permutations
 	active := make([]bool, len(acts0))
 	for i := 0; i < 16384; i++ {
 		j := rand.Intn(len(acts0))
@@ -57,7 +60,7 @@ func TestActive3(t *testing.T) {
 			s0.Cdb.Forall(func(c z.C, h Chd, ms []z.Lit) {
 				for _, m := range ms {
 					if m.Var().Pos() == act {
-						t.Errorf("%s in %s%v\n", act, c, ms)
+						t.Fatalf("%s in %s%v\n", act, c, ms)
 						break
 					}
 				}

--- a/internal/xo/active_test.go
+++ b/internal/xo/active_test.go
@@ -1,0 +1,114 @@
+package xo
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/irifrance/gini/z"
+)
+
+func TestActive3(t *testing.T) {
+	N := 32
+	M := N * 3
+	M -= M / 7
+	s0 := NewS()
+	for i := 0; i < M; i++ {
+		m, n, o := randMs(N)
+		s0.Add(m)
+		s0.Add(n)
+		s0.Add(o)
+		s0.Add(0)
+	}
+	if s0.Solve() != 1 {
+		t.Logf("unlikely unsat rand 3-CNF, starting over")
+		TestActive3(t)
+		return
+	}
+	s1 := s0.Copy()
+	NCs := N*5 - M
+	Cs := make([]z.Lit, 0, NCs*3)
+	acts0 := make([]z.Lit, NCs)
+	acts1 := make([]z.Lit, NCs)
+	for i := 0; i < NCs; i++ {
+		m, n, o := randMs(N)
+
+		s0.Add(m)
+		s0.Add(n)
+		s0.Add(o)
+		acts0[i] = s0.Activate()
+
+		act1 := s1.Lit()
+		acts1[i] = act1
+		s1.Add(m)
+		s1.Add(n)
+		s1.Add(o)
+		s1.Add(act1.Not())
+		s1.Add(0)
+		Cs = append(Cs, m, n, o)
+	}
+	// compare assumptions with activations/de-activations
+	active := make([]bool, len(acts0))
+	for i := 0; i < 16384; i++ {
+		j := rand.Intn(len(acts0))
+		if active[j] {
+			act := acts0[j]
+			s0.Deactivate(act)
+			s0.Cdb.gc.CompactCDat(s0.Cdb)
+			s0.Cdb.Forall(func(c z.C, h Chd, ms []z.Lit) {
+				for _, m := range ms {
+					if m.Var().Pos() == act {
+						t.Errorf("%s in %s%v\n", act, c, ms)
+						break
+					}
+				}
+			})
+		} else {
+			k := 3 * j
+			s0.Add(Cs[k])
+			s0.Add(Cs[k+1])
+			s0.Add(Cs[k+2])
+			acts0[j] = s0.Activate()
+		}
+		active[j] = !active[j]
+		for j := range acts0 {
+			if active[j] {
+				s0.Assume(acts0[j])
+				s1.Assume(acts1[j])
+			}
+		}
+		r0, r1 := s0.Solve(), s1.Solve()
+		if r0 != r1 {
+			s := s0
+			if r0 != -1 {
+				s = s1
+			}
+			t.Fatalf("%d,%d %v\n", r0, r1, s.Why(nil))
+		}
+		//t.Logf("%05d ok %d <%s,%s> %t->%t (%d,%d)", i, j, acts0[j], acts1[j], !active[j], active[j], r0, r1)
+	}
+}
+
+func randMs(N int) (m, n, o z.Lit) {
+	w, x, y := z.Var(rand.Intn(N)), z.Var(rand.Intn(N)), z.Var(rand.Intn(N))
+	w++
+	x++
+	y++
+	for w == x || w == y || x == y {
+		if x == y {
+			x = z.Var(rand.Intn(N))
+		} else {
+			w = z.Var(rand.Intn(N))
+		}
+	}
+	m, n, o = w.Pos(), x.Pos(), y.Pos()
+	if rand.Intn(2) == 1 {
+		m = m.Not()
+	}
+	if rand.Intn(2) == 1 {
+		n = n.Not()
+	}
+	if rand.Intn(2) == 1 {
+		o = o.Not()
+	}
+	return
+}

--- a/internal/xo/cdat_test.go
+++ b/internal/xo/cdat_test.go
@@ -5,8 +5,9 @@ package xo
 
 import (
 	"fmt"
-	"github.com/irifrance/gini/z"
 	"testing"
+
+	"github.com/irifrance/gini/z"
 )
 
 var cnf = [][]z.Lit{
@@ -35,7 +36,7 @@ var left = [...]int{1, 4, 6}
 
 func TestCDat(t *testing.T) {
 	ldb := NewCDat(8)
-	locs := make([]CLoc, 0, 10)
+	locs := make([]z.C, 0, 10)
 	for i, cls := range cnf {
 		locs = append(locs, ldb.AddLits(hds[i], cls))
 	}
@@ -61,7 +62,7 @@ func TestCDat(t *testing.T) {
 	}
 
 	// test compact
-	rm := make([]CLoc, 4, 4)
+	rm := make([]z.C, 4, 4)
 	for i, j := range rmi {
 		rm[i] = locs[j]
 	}
@@ -80,7 +81,7 @@ func TestCDat(t *testing.T) {
 		if !ok {
 			t.Errorf("missing location")
 		}
-		if p == CLocNull {
+		if p == CNull {
 			t.Errorf("left clause indicated as removed in map")
 		}
 		ms = ms[:0]

--- a/internal/xo/cdb.go
+++ b/internal/xo/cdb.go
@@ -175,10 +175,18 @@ func (c *Cdb) Simplify() int {
 	if c.CnfSimp == nil {
 		return 0
 	}
-	stat, rems := c.CnfSimp.Simplify(c.cnfRems)
-	c.Unlink(rems)
-	c.cnfUnlinked += len(c.cnfRems)
-
+	orgRemLen := len(c.cnfRems)
+	var stat int
+	stat, c.cnfRems = c.CnfSimp.Simplify(c.cnfRems)
+	c.cnfUnlinked += len(c.cnfRems) - orgRemLen
+	c.Unlink(c.cnfRems[orgRemLen:])
+	if c.cnfUnlinked < 2048 {
+		return stat
+	}
+	cLocSlice(c.cnfRems).Sort()
+	relocMap, _ := c.CDat.Compact(c.cnfRems)
+	c.gc.relocate(c, relocMap)
+	c.cnfUnlinked = 0
 	return stat
 }
 

--- a/internal/xo/cdb.go
+++ b/internal/xo/cdb.go
@@ -24,9 +24,8 @@ type Cdb struct {
 	Added   []z.C
 	Learnts []z.C
 
-	CnfSimp     inter.CnfSimp
-	cnfRems     []z.C
-	cnfUnlinked int
+	CnfSimp        inter.CnfSimp
+	cnfSimpRmSpace []z.C
 
 	Tracer Tracer
 
@@ -175,19 +174,17 @@ func (c *Cdb) Simplify() int {
 	if c.CnfSimp == nil {
 		return 0
 	}
-	orgRemLen := len(c.cnfRems)
+
+	rems := c.cnfSimpRmSpace
 	var stat int
-	stat, c.cnfRems = c.CnfSimp.Simplify(c.cnfRems)
-	c.cnfUnlinked += len(c.cnfRems) - orgRemLen
-	c.Unlink(c.cnfRems[orgRemLen:])
-	if c.cnfUnlinked < 2048 {
-		return stat
-	}
-	cLocSlice(c.cnfRems).Sort()
-	relocMap, _ := c.CDat.Compact(c.cnfRems)
-	c.gc.relocate(c, relocMap)
-	c.cnfUnlinked = 0
+	stat, rems = c.CnfSimp.Simplify(rems)
+	c.Remove(rems...)
+	c.cnfSimpRmSpace = c.cnfSimpRmSpace[:0]
 	return stat
+}
+
+func (c *Cdb) Remove(cs ...z.C) {
+	c.gc.Remove(c, cs...)
 }
 
 func (c *Cdb) Learn(ms []z.Lit, lbd int) z.C {

--- a/internal/xo/cdb.go
+++ b/internal/xo/cdb.go
@@ -192,14 +192,16 @@ func (c *Cdb) Learn(ms []z.Lit, lbd int) z.C {
 	ret := c.CDat.AddLits(MakeChd(true, lbd, len(ms)), ms)
 	if c.Active != nil {
 		is := c.Active.IsActive
+		occs := c.Active.Occs
 		for _, m := range ms {
 			mv := m.Var()
 			if !is[mv] {
 				continue
 			}
-			occs := c.Active.Occs
+			if m.IsPos() {
+				panic("positive act lit")
+			}
 			occs[mv] = append(occs[mv], ret)
-			break
 		}
 	}
 	msLen := len(ms)
@@ -432,8 +434,8 @@ func (c *Cdb) CheckWatches() []error {
 
 // by default, called when sat as a sanity check.
 func (c *Cdb) CheckModel() []error {
-	if c.Active != nil {
-		// deactivations remove Added clauses, which are unlinked
+	if c.Active != nil || c.CnfSimp != nil {
+		// deactivations and simplificaations remove Added clauses, which are unlinked
 		// until sufficiently large to compact.  compaction
 		// then cleans up Added, which we need here.
 		c.gc.CompactCDat(c)

--- a/internal/xo/cdb.go
+++ b/internal/xo/cdb.go
@@ -432,6 +432,12 @@ func (c *Cdb) CheckWatches() []error {
 
 // by default, called when sat as a sanity check.
 func (c *Cdb) CheckModel() []error {
+	if c.Active != nil {
+		// deactivations remove Added clauses, which are unlinked
+		// until sufficiently large to compact.  compaction
+		// then cleans up Added, which we need here.
+		c.gc.CompactCDat(c)
+	}
 	var m z.Lit
 	D := c.CDat.D
 	signs := c.Vars.Vals

--- a/internal/xo/cdb.go
+++ b/internal/xo/cdb.go
@@ -258,11 +258,6 @@ func (c *Cdb) Decay() {
 	c.CDat.Decay()
 }
 
-func (c *Cdb) Crunch(ms []z.Lit) int {
-
-	return 0
-}
-
 func (c *Cdb) MaybeCompact() (int, int, int) {
 	gc := c.gc
 	if !gc.Ready() {

--- a/internal/xo/cdb_test.go
+++ b/internal/xo/cdb_test.go
@@ -5,9 +5,10 @@ package xo
 
 import (
 	"bytes"
-	"github.com/irifrance/gini/z"
 	"os"
 	"testing"
+
+	"github.com/irifrance/gini/z"
 )
 
 var cnfDat = [...][]z.Lit{
@@ -35,7 +36,7 @@ var learnts = [...][]z.Lit{
 func TestCdbAdd(t *testing.T) {
 	vars := NewVars(512)
 	cdb := NewCdb(vars, 512)
-	locs := make([]CLoc, 0, 12)
+	locs := make([]z.C, 0, 12)
 	for _, c := range cnfDat {
 		for _, m := range c {
 			cdb.Add(m)
@@ -47,7 +48,7 @@ func TestCdbAdd(t *testing.T) {
 		locs = append(locs, p)
 	}
 	for i, p := range locs {
-		if p == CLocNull || p == CLocInf {
+		if p == CNull || p == CInf {
 			continue
 		}
 		pIsBin := cdb.IsBinary(p)
@@ -74,7 +75,7 @@ func TestCdbAdd(t *testing.T) {
 func TestCdbLearn(t *testing.T) {
 	vars := NewVars(512)
 	cdb := NewCdb(vars, 512)
-	locs := make([]CLoc, 0, 12)
+	locs := make([]z.C, 0, 12)
 	for i, c := range learnts {
 		locs = append(locs, cdb.Learn(c, i))
 	}
@@ -89,7 +90,7 @@ func TestCdbLearnNil(t *testing.T) {
 	vars := NewVars(10)
 	cdb := NewCdb(vars, 20)
 	cdb.Learn(nil, 0)
-	if cdb.Bot == CLocNull {
+	if cdb.Bot == CNull {
 		t.Errorf("cdb.Bot not set\n")
 	}
 }

--- a/internal/xo/cgc.go
+++ b/internal/xo/cgc.go
@@ -132,6 +132,7 @@ func (c *Cgc) Compact(cdb *Cdb) (int, int, int) {
 	return len(rms), nc, n
 }
 
+// NB this is only from cgc.Compact, not cdb.Simplify
 func (c *Cgc) CompactCDat(cdb *Cdb) (int, int) {
 	c.stCDatGcs++
 	c.rmLits = 0

--- a/internal/xo/cgc.go
+++ b/internal/xo/cgc.go
@@ -171,6 +171,10 @@ func (c *Cgc) relocate(cdb *Cdb, rlm map[z.C]z.C) {
 	cdb.Vars.Reasons = relocateSlice(cdb.Vars.Reasons, rlm)
 	// watches
 	c.relocateWatches(cdb, rlm)
+	// activation occs
+	if cdb.Active != nil {
+		cdb.Active.CRemap(rlm)
+	}
 	// simp
 	if cdb.CnfSimp != nil {
 		cdb.CnfSimp.CRemap(rlm)

--- a/internal/xo/cgc.go
+++ b/internal/xo/cgc.go
@@ -4,8 +4,9 @@
 package xo
 
 import (
-	"github.com/irifrance/gini/z"
 	"sort"
+
+	"github.com/irifrance/gini/z"
 )
 
 // Type Cgc encapsulates clause compaction/garbage collection.
@@ -17,7 +18,7 @@ type Cgc struct {
 	factor    uint
 	stopWatch uint // make int and regularize diff between tick and compact?
 
-	rmq []CLoc
+	rmq []z.C
 
 	rmLits int
 	rmd    int
@@ -36,7 +37,7 @@ func NewCgc() *Cgc {
 		luby:       l,
 		factor:     2048,
 		stopWatch:  2048 * l.Next(),
-		rmq:        make([]CLoc, 0, 1024),
+		rmq:        make([]z.C, 0, 1024),
 		rmLits:     0,
 		rmd:        0,
 		stCompacts: 0,
@@ -53,7 +54,7 @@ func (c *Cgc) Copy() *Cgc {
 		luby:      l,
 		factor:    2048,
 		stopWatch: 2048 * l.Next(),
-		rmq:       make([]CLoc, len(c.rmq), cap(c.rmq)),
+		rmq:       make([]z.C, len(c.rmq), cap(c.rmq)),
 		rmLits:    c.rmLits,
 		rmd:       c.rmd}
 	copy(other.rmq, c.rmq)
@@ -91,7 +92,7 @@ func (c *Cgc) Compact(cdb *Cdb) (int, int, int) {
 	top := sz - 1
 	lim := sz / 2
 	rmLitCount := 0
-	rms := make([]CLoc, 0, lim)
+	rms := make([]z.C, 0, lim)
 	// maybe should go in ascending order...--nope!
 	for n := top; n >= 0; n-- {
 		p := learnts[n]
@@ -143,13 +144,17 @@ func (c *Cgc) CompactCDat(cdb *Cdb) (int, int) {
 	return len(crm), freed
 }
 
-func (c *Cgc) relocate(cdb *Cdb, rlm map[CLoc]CLoc) {
+func (c *Cgc) relocate(cdb *Cdb, rlm map[z.C]z.C) {
 	cdb.Learnts = relocateSlice(cdb.Learnts, rlm)
 	cdb.Added = relocateSlice(cdb.Added, rlm)
 	// reasons
 	cdb.Vars.Reasons = relocateSlice(cdb.Vars.Reasons, rlm)
 	// watches
 	c.relocateWatches(cdb, rlm)
+	// simp
+	if cdb.CnfSimp != nil {
+		cdb.CnfSimp.CRemap(rlm)
+	}
 }
 
 func (c *Cgc) readStats(st *Stats) {
@@ -166,7 +171,7 @@ func (c *Cgc) readStats(st *Stats) {
 	c.stRmdLits = 0
 }
 
-func (c *Cgc) relocateWatches(cdb *Cdb, rlm map[CLoc]CLoc) {
+func (c *Cgc) relocateWatches(cdb *Cdb, rlm map[z.C]z.C) {
 	watches := cdb.Vars.Watches
 	for i, ws := range watches {
 		if i < 2 {
@@ -175,7 +180,7 @@ func (c *Cgc) relocateWatches(cdb *Cdb, rlm map[CLoc]CLoc) {
 		m := z.Lit(i)
 		j := 0
 		for _, w := range ws {
-			p := w.CLoc()
+			p := w.C()
 			q, ok := rlm[p]
 			if !ok { // not relocated or removed.
 				ws[j] = w
@@ -184,7 +189,7 @@ func (c *Cgc) relocateWatches(cdb *Cdb, rlm map[CLoc]CLoc) {
 			}
 			// NB this condition only makes sense when "ok" is true,
 			// then we know p was removed.
-			if q == CLocNull {
+			if q == CNull {
 				continue
 			}
 			// relocated and kept
@@ -196,7 +201,7 @@ func (c *Cgc) relocateWatches(cdb *Cdb, rlm map[CLoc]CLoc) {
 }
 
 type gcLearnts struct {
-	learnts []CLoc
+	learnts []z.C
 	cdat    *CDat
 }
 
@@ -246,7 +251,7 @@ func (p *gcLearnts) Sort() {
 	sort.Sort(p)
 }
 
-type cLocSlice []CLoc
+type cLocSlice []z.C
 
 func (p cLocSlice) Len() int {
 	return len(p)
@@ -264,7 +269,7 @@ func (p cLocSlice) Sort() {
 	sort.Sort(p)
 }
 
-func relocateSlice(ps []CLoc, m map[CLoc]CLoc) []CLoc {
+func relocateSlice(ps []z.C, m map[z.C]z.C) []z.C {
 	j := 0
 	for _, p := range ps {
 		q, ok := m[p]
@@ -273,7 +278,7 @@ func relocateSlice(ps []CLoc, m map[CLoc]CLoc) []CLoc {
 			j++
 			continue
 		}
-		if q == CLocNull {
+		if q == CNull {
 			continue
 		}
 		ps[j] = q

--- a/internal/xo/cgc.go
+++ b/internal/xo/cgc.go
@@ -93,6 +93,27 @@ func (gc *Cgc) Remove(cdb *Cdb, cs ...z.C) {
 	gc.CompactCDat(cdb) // also unlinks
 }
 
+func uniq(cs []z.C) []z.C {
+	if len(cs) <= 1 {
+		return cs
+	}
+	i := 0
+	j := 1
+	last := cs[0]
+	var cur z.C
+	N := len(cs)
+	for j < N {
+		cur = cs[j]
+		if cur != last {
+			i++
+			cs[i] = cur
+			last = cur
+		}
+		j++
+	}
+	return cs[:i+1]
+}
+
 // Compact runs a clause gc, which in turn sometimes
 // compacts the underlying CDat.  Compact returns
 //
@@ -158,6 +179,10 @@ func (c *Cgc) CompactCDat(cdb *Cdb) (int, int) {
 	c.rmd = 0
 	crm := c.rmq
 	cLocSlice(crm).Sort()
+	if cdb.Active != nil || cdb.CnfSimp != nil {
+		crm = uniq(crm)
+		// otherwise, it's only learnts and uniq by construction.
+	}
 	relocMap, freed := cdb.CDat.Compact(crm)
 	c.relocate(cdb, relocMap)
 	c.rmq = c.rmq[:0]

--- a/internal/xo/cgc.go
+++ b/internal/xo/cgc.go
@@ -172,14 +172,14 @@ func (c *Cgc) Compact(cdb *Cdb) (int, int, int) {
 	return len(rms), nc, n
 }
 
-// NB this is only from cgc.Compact, not cdb.Simplify
+// NB this is only from cgc.Compact
 func (c *Cgc) CompactCDat(cdb *Cdb) (int, int) {
 	c.stCDatGcs++
 	c.rmLits = 0
 	c.rmd = 0
 	crm := c.rmq
 	cLocSlice(crm).Sort()
-	if cdb.Active != nil || cdb.CnfSimp != nil {
+	if cdb.Active != nil {
 		crm = uniq(crm)
 		// otherwise, it's only learnts and uniq by construction.
 	}
@@ -199,10 +199,6 @@ func (c *Cgc) relocate(cdb *Cdb, rlm map[z.C]z.C) {
 	// activation occs
 	if cdb.Active != nil {
 		cdb.Active.CRemap(rlm)
-	}
-	// simp
-	if cdb.CnfSimp != nil {
-		cdb.CnfSimp.CRemap(rlm)
 	}
 }
 

--- a/internal/xo/cgc.go
+++ b/internal/xo/cgc.go
@@ -74,6 +74,25 @@ func (c *Cgc) Ready() bool {
 	return c.stopWatch <= 0
 }
 
+func (gc *Cgc) Remove(cdb *Cdb, cs ...z.C) {
+	rmLitCount := 0
+	for _, c := range cs {
+		rmLitCount += cdb.Size(c)
+	}
+
+	gc.rmq = append(gc.rmq, cs...)
+	gc.rmd += len(cs)
+	gc.stRmd += int64(len(cs))
+	gc.stRmdLits += int64(rmLitCount)
+	gc.rmLits += rmLitCount
+	if !cdb.CDat.CompactReady(gc.rmd, gc.rmLits) {
+		cdb.Unlink(cs)
+		return
+	}
+	//  free literal data
+	gc.CompactCDat(cdb) // also unlinks
+}
+
 // Compact runs a clause gc, which in turn sometimes
 // compacts the underlying CDat.  Compact returns
 //

--- a/internal/xo/cloc.go
+++ b/internal/xo/cloc.go
@@ -3,17 +3,9 @@
 
 package xo
 
-import "fmt"
-
-// Type CLoc gives a temporary id which directly
-// tells where the sequence of literals (zero/LitNull terminated) starts
-type CLoc uint32
+import "github.com/irifrance/gini/z"
 
 const (
-	CLocNull CLoc = 0
-	CLocInf       = 0xffffffff
+	CNull z.C = 0
+	CInf      = 0xffffffff
 )
-
-func (p CLoc) String() string {
-	return fmt.Sprintf("c%d", p)
-}

--- a/internal/xo/derive.go
+++ b/internal/xo/derive.go
@@ -5,6 +5,7 @@ package xo
 
 import (
 	"fmt"
+
 	"github.com/irifrance/gini/z"
 )
 
@@ -65,7 +66,7 @@ func (d *Deriver) CopyWith(cdb *Cdb, g *Guess, t *Trail) *Deriver {
 }
 
 type Derived struct {
-	P           CLoc
+	P           z.C
 	Unit        z.Lit
 	Size        int
 	TargetLevel int
@@ -76,7 +77,7 @@ func (d *Deriver) String() string {
 		100.0*float64(d.RedLits)/float64(d.RedLits+d.LearntLits))
 }
 
-func (d *Deriver) Derive(x CLoc) *Derived {
+func (d *Deriver) Derive(x z.C) *Derived {
 	d.Conflicts++
 	// find 1uip
 	count := 0
@@ -103,9 +104,9 @@ func (d *Deriver) Derive(x CLoc) *Derived {
 	lbd := 0
 
 	for i := d.Trail.Tail - 1; i >= 0; i-- {
-		if p != CLocNull {
+		if p != CNull {
 			// count/mark lits in reason clause or conflict
-			// p is normal CLoc for conflict, +1 for unit.
+			// p is normal z.C for conflict, +1 for unit.
 			for {
 				m = ldb[p]
 				if m == z.LitNull {
@@ -139,7 +140,7 @@ func (d *Deriver) Derive(x CLoc) *Derived {
 				guess.Bump(m)
 				count++
 			}
-			p = CLocNull
+			p = CNull
 		}
 		m = trail[i]
 		v = m.Var()
@@ -253,7 +254,7 @@ func (d *Deriver) isRdntRec(m z.Lit) bool {
 			return false
 		}
 		p := d.Vars.Reasons[v]
-		if p == CLocNull {
+		if p == CNull {
 			d.Rdnt[v] = -1
 			return false
 		}

--- a/internal/xo/derive.go
+++ b/internal/xo/derive.go
@@ -249,7 +249,8 @@ func (d *Deriver) isRdntRec(m z.Lit) bool {
 	switch d.Rdnt[v] {
 	case 0:
 		d.RLits = append(d.RLits, m)
-		if !d.Lvls[d.Vars.Levels[v]] {
+		lvl := d.Vars.Levels[v]
+		if !d.Lvls[lvl] {
 			d.Rdnt[v] = -1
 			return false
 		}

--- a/internal/xo/doc.go
+++ b/internal/xo/doc.go
@@ -38,12 +38,12 @@
 //  - an abstraction of the size of the clause
 //  - "heat", a heuristic score of activity in solving.
 //
-// Each clause is also associated with a CLoc, which is a 32bit offset into
+// Each clause is also associated with a z.C, which is a 32bit offset into
 // the data store slice of lits.  This is the identifier for a clause, which
 // can change over time due to clause garbage collection during the solving
 // process.
 //
-// Each CLoc p points to data layed out as follows.
+// Each z.C p points to data layed out as follows.
 //
 //   [... Chd lit0 lit1 ... litn LitNull]
 //            p
@@ -118,7 +118,7 @@
 //
 //  - Lit; m,n,o
 //  - Var: u,v
-//  - CLoc: p,q,r
+//  - z.C: p,q,r
 //  - Watch: w -
 //  - Slices ([]): add an s on the end of underlying type
 //  - Slice indices: i,j,k

--- a/internal/xo/guess.go
+++ b/internal/xo/guess.go
@@ -4,8 +4,9 @@
 package xo
 
 import (
-	"github.com/irifrance/gini/z"
 	"math"
+
+	"github.com/irifrance/gini/z"
 )
 
 const (
@@ -75,7 +76,7 @@ func NewGuessCdb(cdb *Cdb) *Guess {
 		g.pos[i] = j
 	}
 	inc := 0.001
-	cdb.Forall(func(p CLoc, h Chd, ms []z.Lit) {
+	cdb.Forall(func(p z.C, h Chd, ms []z.Lit) {
 		for _, m := range ms {
 			if h.Size() >= 16 {
 				continue

--- a/internal/xo/s.go
+++ b/internal/xo/s.go
@@ -566,6 +566,7 @@ func (s *S) Assume(ms ...z.Lit) {
 	defer s.unlock()
 	s.stAssumes += int64(len(ms))
 	s.assumes = append(s.assumes, ms...)
+	fmt.Printf("assume %v\n", s.assumes)
 }
 
 // Who identifies the solver and configuration.

--- a/internal/xo/s.go
+++ b/internal/xo/s.go
@@ -284,16 +284,6 @@ func (s *S) Solve() int {
 	}
 }
 
-// Simplify implements inter.Simplifier
-func (s *S) Simplify() int {
-	return s.Cdb.Simplify()
-}
-
-// SetCnfSimp implements inter.Simplifier
-func (s *S) SetCnfSimp(simp inter.CnfSimp) {
-	s.Cdb.CnfSimp = simp
-}
-
 // Value retrieves the value of the literal m
 func (s *S) Value(m z.Lit) bool {
 	s.rmu.Lock()

--- a/internal/xo/s.go
+++ b/internal/xo/s.go
@@ -566,7 +566,6 @@ func (s *S) Assume(ms ...z.Lit) {
 	defer s.unlock()
 	s.stAssumes += int64(len(ms))
 	s.assumes = append(s.assumes, ms...)
-	fmt.Printf("assume %v\n", s.assumes)
 }
 
 // Who identifies the solver and configuration.

--- a/internal/xo/s.go
+++ b/internal/xo/s.go
@@ -519,6 +519,12 @@ func (s *S) Activate() z.Lit {
 	return m
 }
 
+func (s *S) ActivationLit() z.Lit {
+	s.ensure0()
+	s.ensureActive()
+	return s.Active.Lit(s)
+}
+
 func (s *S) ActivateWith(act z.Lit) {
 	s.ensure0()
 	s.ensureActive()

--- a/internal/xo/s.go
+++ b/internal/xo/s.go
@@ -415,6 +415,11 @@ func (s *S) Untest() int {
 		panic("Untest without Test")
 	}
 	trail := s.Trail
+	if s.x != CNull {
+		drvd := s.Driver.Derive(s.x)
+		trail.Assign(drvd.Unit, drvd.P)
+		s.x = CNull
+	}
 	lastTestLevel := s.lastTestLevel()
 	s.testLevels = s.testLevels[:len(s.testLevels)-1]
 	s.endTestLevel = lastTestLevel

--- a/internal/xo/s_test.go
+++ b/internal/xo/s_test.go
@@ -402,6 +402,46 @@ func TestIncAdd(t *testing.T) {
 	}
 }
 
+func TestAddTestPanic(t *testing.T) {
+	defer func() {
+		if x := recover(); x == nil {
+			t.Errorf("didn't panic when adding under assumptions")
+		}
+	}()
+	s := NewS()
+	a, b := s.Lit(), s.Lit()
+	s.Assume(a)
+	s.Test(nil)
+	s.Add(a)
+	s.Add(b)
+	s.Add(0)
+}
+
+func TestActivateTestPanic(t *testing.T) {
+	defer func() {
+		if x := recover(); x == nil {
+			t.Errorf("didn't panic when activating under assumptions")
+		}
+	}()
+	s := NewS()
+	a, b := s.Lit(), s.Lit()
+	s.Assume(a)
+	s.Test(nil)
+	s.Add(a)
+	s.Add(b)
+	s.Activate()
+}
+
+func TestActivateEmptyClausePanic(t *testing.T) {
+	defer func() {
+		if x := recover(); x == nil {
+			t.Errorf("didn't panic when activating empty clause")
+		}
+	}()
+	s := NewS()
+	s.Activate()
+}
+
 func TestActivations(t *testing.T) {
 	s := NewS()
 	for i := 1; i < 31; i++ {

--- a/internal/xo/trail.go
+++ b/internal/xo/trail.go
@@ -6,12 +6,13 @@ package xo
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/irifrance/gini/z"
 )
 
 type late struct {
 	m z.Lit
-	r CLoc
+	r z.C
 }
 
 type Trail struct {
@@ -55,14 +56,14 @@ func (t *Trail) CopyWith(cdb *Cdb, guess *Guess) *Trail {
 	return other
 }
 
-func (t *Trail) Assign(m z.Lit, c CLoc) {
+func (t *Trail) Assign(m z.Lit, c z.C) {
 	v := m.Var()
 	t.D[t.Tail] = m
 	t.Tail++
 	vars := t.Vars
 	vars.Reasons[v] = c
 
-	if c == CLocNull {
+	if c == CNull {
 		t.Level++
 	}
 	vars.Levels[v] = t.Level
@@ -101,7 +102,7 @@ func (t *Trail) Back(trgLevel int) {
 		}
 		vals[m] = 0
 		vals[m.Not()] = 0
-		reasons[v] = CLocNull
+		reasons[v] = CNull
 		lvls[v] = -1
 		guess.Push(m) // actually only adds it if it is not already there.
 	}
@@ -111,14 +112,14 @@ func (t *Trail) Back(trgLevel int) {
 	t.Level = 0
 }
 
-func (t *Trail) Prop() CLoc {
+func (t *Trail) Prop() z.C {
 	vals := t.Vars.Vals
 	data := t.D
 	watches := t.Vars.Watches
 	cdb := t.Cdb
 	cdat := cdb.CDat.D
 	var mWatches []Watch
-	var p, q CLoc
+	var p, q z.C
 	var o z.Lit
 	var m z.Lit
 	var n z.Lit
@@ -141,7 +142,7 @@ func (t *Trail) Prop() CLoc {
 				continue
 			}
 
-			q = w.CLoc()
+			q = w.C()
 			if w.IsBinary() {
 				if cdat[q] == m {
 					cdat[q], cdat[q+1] = o, m
@@ -233,7 +234,7 @@ func (t *Trail) Prop() CLoc {
 	if t.Tail > t.MaxTail {
 		t.MaxTail = t.Tail
 	}
-	return CLocNull
+	return CNull
 }
 
 // backWithLates is used by Untest to go back one level of assumptions.
@@ -252,7 +253,7 @@ func (t *Trail) backWithLates(prevLevel int) {
 	for i := t.Tail - 1; i >= 0; i-- {
 		m := t.D[i]
 		r := reasons[m.Var()]
-		if r == CLocNull {
+		if r == CNull {
 			lvl--
 			if lvl == prevLevel {
 				break
@@ -292,7 +293,7 @@ func (t *Trail) String() string {
 	for i := 0; i < t.Tail; i++ {
 		m := t.D[i]
 		r := reasons[m.Var()]
-		if r == CLocNull {
+		if r == CNull {
 			level++
 			buf.WriteString(fmt.Sprintf("\tLevel %d:\n", level))
 		}

--- a/internal/xo/trail_test.go
+++ b/internal/xo/trail_test.go
@@ -4,10 +4,11 @@
 package xo
 
 import (
-	"github.com/irifrance/gini/gen"
-	"github.com/irifrance/gini/z"
 	"math/rand"
 	"testing"
+
+	"github.com/irifrance/gini/gen"
+	"github.com/irifrance/gini/z"
 )
 
 func TestTrailBack(t *testing.T) {
@@ -19,9 +20,9 @@ func TestTrailBack(t *testing.T) {
 	for i := 0; i < N/2; i++ {
 		for j := 0; j < i; j++ {
 			m := z.Var(j + 1).Pos()
-			trail.Assign(m, CLocNull)
+			trail.Assign(m, CNull)
 			x := trail.Prop()
-			if x != CLocNull {
+			if x != CNull {
 				trail.Back(0)
 				return
 			}
@@ -43,9 +44,9 @@ func TestTrailBinarySat(t *testing.T) {
 	gen.BinCycle(dst, N)
 	cdb := dst.Cdb
 	trail := NewTrail(cdb, newGuess(N))
-	trail.Assign(z.Lit(2), CLocNull)
+	trail.Assign(z.Lit(2), CNull)
 	x := trail.Prop()
-	if x != CLocNull {
+	if x != CNull {
 		t.Errorf("binary cycle: unexpected conflict")
 	}
 	if trail.Tail != N {
@@ -62,9 +63,9 @@ func TestTrailBinaryUnsat(t *testing.T) {
 	p, _ := cdb.Add(z.LitNull)
 	trail := NewTrail(cdb, newGuess(N))
 	trail.Assign(z.Lit(4), p)
-	trail.Assign(z.Lit(7), CLocNull)
+	trail.Assign(z.Lit(7), CNull)
 	x := trail.Prop()
-	if x == CLocNull {
+	if x == CNull {
 		t.Errorf("binary cycle: expected conflict")
 	}
 }
@@ -75,16 +76,16 @@ func TestTrailTernary(t *testing.T) {
 	gen.Rand3Cnf(dst, N, N*4)
 	cdb := dst.Cdb
 	trail := NewTrail(cdb, newGuess(N))
-	x := CLocNull
+	x := CNull
 	vals := cdb.Vars.Vals
-	for x == CLocNull && trail.Tail != N {
+	for x == CNull && trail.Tail != N {
 		m := z.Lit(2)
 		for vals[m] != 0 {
 			m = z.Lit(rand.Intn(N*2) + 2)
 		}
-		trail.Assign(m, CLocNull)
+		trail.Assign(m, CNull)
 		x = trail.Prop()
-		if x != CLocNull {
+		if x != CNull {
 			trail.Back(trail.Level - 1)
 		}
 		errs := cdb.CheckWatches()

--- a/internal/xo/vars.go
+++ b/internal/xo/vars.go
@@ -5,15 +5,16 @@ package xo
 
 import (
 	"fmt"
-	"github.com/irifrance/gini/z"
 	"strings"
+
+	"github.com/irifrance/gini/z"
 )
 
 type Vars struct {
 	Max     z.Var // maximum value of a used variable
 	Top     z.Var // number of allocated variables, 1-indexed
 	Vals    []int8
-	Reasons []CLoc
+	Reasons []z.C
 	Levels  []int
 	Watches [][]Watch
 }
@@ -25,7 +26,7 @@ func NewVars(capHint int) *Vars {
 	top := capHint + 1
 	v := &Vars{Max: z.Var(0),
 		Top:     z.Var(top),
-		Reasons: make([]CLoc, top),
+		Reasons: make([]z.C, top),
 		Levels:  make([]int, top),
 		Vals:    make([]int8, 2*top),
 		Watches: make([][]Watch, 2*top)}
@@ -63,7 +64,7 @@ func (v *Vars) growToVar(u z.Var) {
 	copy(vs, v.Vals)
 	v.Vals = vs
 
-	rs := make([]CLoc, w)
+	rs := make([]z.C, w)
 	copy(rs, v.Reasons)
 	v.Reasons = rs
 
@@ -82,7 +83,7 @@ func (v *Vars) Copy() *Vars {
 		Max:     v.Max,
 		Top:     v.Top,
 		Vals:    make([]int8, len(v.Vals), cap(v.Vals)),
-		Reasons: make([]CLoc, len(v.Reasons), cap(v.Reasons)),
+		Reasons: make([]z.C, len(v.Reasons), cap(v.Reasons)),
 		Levels:  make([]int, len(v.Levels), cap(v.Levels)),
 		Watches: make([][]Watch, len(v.Watches), cap(v.Watches))}
 	copy(other.Vals, v.Vals)

--- a/internal/xo/watch.go
+++ b/internal/xo/watch.go
@@ -5,6 +5,7 @@ package xo
 
 import (
 	"fmt"
+
 	"github.com/irifrance/gini/z"
 )
 
@@ -23,7 +24,7 @@ const (
 // MakeWatch creates a watch object for clause location loc
 // blocking literal o, and isBin indicating whether the referred to
 // clause is binary (comprised of 2 literals)
-func MakeWatch(loc CLoc, o z.Lit, isBin bool) Watch {
+func MakeWatch(loc z.C, o z.Lit, isBin bool) Watch {
 	v := uint64(0)
 	if isBin {
 		v |= binMask
@@ -44,13 +45,13 @@ func (w Watch) IsBinary() bool {
 }
 
 // the location of the null-terminated literals in the clause
-func (w Watch) CLoc() CLoc {
-	return CLoc(w >> litBits)
+func (w Watch) C() z.C {
+	return z.C(w >> litBits)
 }
 
-// return a watch with all info the same, but the CLoc updated
+// return a watch with all info the same, but the z.C updated
 // to o.
-func (w Watch) Relocate(o CLoc) Watch {
+func (w Watch) Relocate(o z.C) Watch {
 	v := uint64(w)
 	v &= ^locMask
 	v |= uint64(o) << litBits
@@ -59,5 +60,5 @@ func (w Watch) Relocate(o CLoc) Watch {
 
 // a human readable representation
 func (w Watch) String() string {
-	return fmt.Sprintf("Watch{CLoc: %s, Other: %s, Bin: %t}", w.CLoc(), w.Other(), w.IsBinary())
+	return fmt.Sprintf("Watch{z.C: %s, Other: %s, Bin: %t}", w.C(), w.Other(), w.IsBinary())
 }

--- a/internal/xo/watch_test.go
+++ b/internal/xo/watch_test.go
@@ -5,21 +5,22 @@ package xo
 
 import (
 	"fmt"
-	"github.com/irifrance/gini/z"
 	"testing"
+
+	"github.com/irifrance/gini/z"
 )
 
 func TestLocOverflow(t *testing.T) {
-	loc := CLoc(3)
+	loc := z.C(3)
 	w := MakeWatch(loc, 7, true)
-	loc2 := w.CLoc()
-	if w.CLoc() != loc {
+	loc2 := w.C()
+	if w.C() != loc {
 		t.Errorf("error isbin overflow?: %s != %s", loc, loc2)
 	}
 }
 
 func TestWatch(t *testing.T) {
-	loc := CLoc(77)
+	loc := z.C(77)
 	m := z.Lit(1024)
 	isBin := true
 	w := MakeWatch(loc, m, isBin)
@@ -30,11 +31,11 @@ func TestWatch(t *testing.T) {
 	if w.IsBinary() != isBin {
 		t.Errorf("isBind decode: %t != %t", w.IsBinary(), isBin)
 	}
-	if w.CLoc() != loc {
-		t.Errorf("loc en/decode: %s != %s", w.CLoc(), loc)
+	if w.C() != loc {
+		t.Errorf("loc en/decode: %s != %s", w.C(), loc)
 	}
 
-	newLoc := CLoc(22)
+	newLoc := z.C(22)
 	w0 := w.Relocate(newLoc)
 	if w0.Other() != m {
 		t.Errorf("relocate other: %s != %s", w0.Other(), m)
@@ -42,7 +43,7 @@ func TestWatch(t *testing.T) {
 	if w0.IsBinary() != isBin {
 		t.Errorf("isBin decode %t != %t", w0.IsBinary(), isBin)
 	}
-	if w0.CLoc() != newLoc {
-		t.Errorf("relocate  newloc %s != %s", w0.CLoc(), newLoc)
+	if w0.C() != newLoc {
+		t.Errorf("relocate  newloc %s != %s", w0.C(), newLoc)
 	}
 }

--- a/logic/unroll.go
+++ b/logic/unroll.go
@@ -5,17 +5,17 @@ package logic
 
 import "github.com/irifrance/gini/z"
 
-// Type Unroll creates an unroller of sequential logic into
+// Type Roll creates an unroller of sequential logic into
 // combinational logic.
-type Unroll struct {
+type Roll struct {
 	S    *S // the sequential circuit
 	C    *C // the resulting comb circuit
 	dmap [][]z.Lit
 }
 
-// NewUnroll creates a new unroller for s
-func NewUnroll(s *S) *Unroll {
-	u := &Unroll{
+// NewRoll creates a new unroller for s
+func NewRoll(s *S) *Roll {
+	u := &Roll{
 		S:    s,
 		C:    NewCCap(s.Len() * 10),
 		dmap: make([][]z.Lit, s.Len())}
@@ -23,14 +23,14 @@ func NewUnroll(s *S) *Unroll {
 }
 
 // Len returns the length of the unrolling for literal m.
-func (u *Unroll) Len(m z.Lit) int {
+func (u *Roll) Len(m z.Lit) int {
 	v := m.Var()
 	return len(u.dmap[v])
 }
 
 // MaxLen returns the maximum length of any literal in
 // the unrolling.
-func (u *Unroll) MaxLen() int {
+func (u *Roll) MaxLen() int {
 	ns := u.S.nodes
 	max := 0
 	for i := 1; i < len(ns); i++ {
@@ -47,7 +47,7 @@ func (u *Unroll) MaxLen() int {
 // u.S at time/depth d as a literal in u.C
 //
 // If d < 0, then At panics.
-func (u *Unroll) At(m z.Lit, d int) z.Lit {
+func (u *Roll) At(m z.Lit, d int) z.Lit {
 	v := m.Var()
 	if len(u.dmap[v]) < d {
 		u.At(m, d-1)

--- a/logic/unroll_test.go
+++ b/logic/unroll_test.go
@@ -21,7 +21,7 @@ func TestUnrollComb(t *testing.T) {
 	a3 := s.And(a1, i1.Not())
 	a4 := s.And(a2, a3)
 
-	u := logic.NewUnroll(s)
+	u := logic.NewRoll(s)
 	u.At(a4, 3)
 	if u.C.Len() != 2+((u.S.Len()-2)*4) {
 		t.Errorf("wrong length expected %d got %d\n", 2+((u.S.Len()-2)*3), u.C.Len())
@@ -32,7 +32,7 @@ func TestUnrollLatch(t *testing.T) {
 	s := logic.NewS()
 	m := s.Latch(s.F)
 	s.SetNext(m, m.Not())
-	u := logic.NewUnroll(s)
+	u := logic.NewRoll(s)
 	u.At(m, 3)
 }
 
@@ -40,7 +40,7 @@ func TestUnrollConst(t *testing.T) {
 	s := logic.NewS()
 	m := s.Latch(s.F)
 	s.SetNext(m, m.Not())
-	u := logic.NewUnroll(s)
+	u := logic.NewRoll(s)
 	if u.At(s.T, 24) != u.C.T {
 		t.Errorf("unroll T")
 	}
@@ -56,7 +56,7 @@ func TestUnrollCnfSince(t *testing.T) {
 	o := s.Or(m, n)
 	s.SetNext(m, o)
 
-	u := logic.NewUnroll(s)
+	u := logic.NewRoll(s)
 	var mark []int8
 	sat := gini.New()
 	ttl := 0
@@ -83,7 +83,7 @@ func TestUnrollCnfCounter(t *testing.T) {
 	}
 	// set up unrolling and sat
 	end := 1<<uint(N) - 1
-	unroller := logic.NewUnroll(s)
+	unroller := logic.NewRoll(s)
 	var mark []int8
 	sat := gini.New()
 	// for all but 'end', 'carry' should be false.
@@ -115,7 +115,7 @@ func ExampleUnroll() {
 	}
 
 	// create an unroller.
-	u := logic.NewUnroll(s)
+	u := logic.NewRoll(s)
 	// unroll until all 1s
 	D := (1 << uint(N)) - 1
 	errs := 0

--- a/z/c.go
+++ b/z/c.go
@@ -1,0 +1,12 @@
+package z
+
+import "fmt"
+
+// C is a clause ref.  Clause refs are ephemeral and
+// may change value during solves. Clause refs are used by objects
+// implementing inter.CnfSimp
+type C uint32
+
+func (p C) String() string {
+	return fmt.Sprintf("c%d", p)
+}


### PR DESCRIPTION
This PR adds recyclable activation literal support to gini.

This was tricky, and so testing is correspondingly robust.

Also, this PR clarifies and extends some things about incremental usage:

Add and Activation related stuff can't happen under a test scope.
Activation works with test scopes
test scopes work with unsat results under subsequent assumptions now.




