### PR TITLE
Incremental Performance Improvements

### DIFF
--- a/gen/rands.go
+++ b/gen/rands.go
@@ -102,6 +102,13 @@ func (r *randS) Solve() int {
 	defer r.unlock()
 	return r.solve()
 }
+
+func (r *randS) Try(dur time.Duration) int {
+	r.lock()
+	defer r.unlock()
+	return r.solve()
+}
+
 func (r *randS) solve() int {
 	r.ms = r.ms[:0]
 	ns := r.dur.Nanoseconds()

--- a/gini.go
+++ b/gini.go
@@ -5,6 +5,7 @@ package gini
 
 import (
 	"io"
+	"time"
 
 	"github.com/irifrance/gini/dimacs"
 	"github.com/irifrance/gini/inter"
@@ -122,6 +123,11 @@ func (g *Gini) Assume(ms ...z.Lit) {
 func (g *Gini) Solve() int {
 	res := g.xo.Solve()
 	return res
+}
+
+// Try solves with a timeout.
+func (g *Gini) Try(dur time.Duration) int {
+	return g.xo.Try(dur)
 }
 
 // GoSolve provides a connection to a single background

--- a/gini.go
+++ b/gini.go
@@ -125,7 +125,10 @@ func (g *Gini) Solve() int {
 	return res
 }
 
-// Try solves with a timeout.
+// Try solves with a timeout.  Try returns
+//  1  if sat
+//  -1 if unsat
+//  0  if timeout
 func (g *Gini) Try(dur time.Duration) int {
 	return g.xo.Try(dur)
 }

--- a/gini_test.go
+++ b/gini_test.go
@@ -4,7 +4,6 @@
 package gini
 
 import (
-	"math/rand"
 	"testing"
 	"time"
 
@@ -59,96 +58,5 @@ func TestGiniAsync(t *testing.T) {
 	if sDur > timeout+margin {
 		// CI builders don't like this and have unreasonable values.
 		t.Logf("cancelled late. %s > %s", sDur, timeout)
-	}
-}
-
-type dummySimp struct {
-	toRm   []z.C
-	toKeep []z.C
-	tst    *testing.T
-}
-
-func (d *dummySimp) OnAdded(c z.C, ms []z.Lit) {
-	for _, m := range ms {
-		if m.Var() == 1024 {
-			d.toRm = append(d.toRm, c)
-			return
-		}
-	}
-	d.toKeep = append(d.toKeep, c)
-}
-
-func (d *dummySimp) CRemap(cm map[z.C]z.C) {
-	for i, c := range d.toKeep {
-		n, ok := cm[c]
-		if !ok {
-			continue
-		}
-		if n == 0 {
-			d.tst.Errorf("got CNull on remap")
-			continue
-		}
-		d.toKeep[i] = n
-	}
-}
-
-func (d *dummySimp) Simplify(rmSpace []z.C) (status int, rms []z.C) {
-	rms = rmSpace
-	rms = append(rms, d.toRm...)
-	d.toRm = d.toRm[:0]
-	status = 0
-	return
-}
-
-func TestCnfSimp(t *testing.T) {
-	// we do pure lit on 1024, and create a formula with >2048 clauses
-	// containing 1024 together with a 64 variable random 3cnf near the
-	// cutoff of sat/unsat equal probability
-	for n := 0; n < 32; n++ {
-		s0, s1 := New(), New()
-		s0.SetCnfSimp(&dummySimp{tst: t})
-		pure := z.Var(1024).Pos()
-		with := z.Var(1025).Pos()
-		for i := 0; i < 2049; i++ { // 2049 because 2048 is the limit to cause lit removal.
-			// not unit so they will all add
-			s0.Add(pure)
-			s0.Add(with)
-			s0.Add(0)
-			s1.Add(pure)
-			s1.Add(with)
-			s1.Add(0)
-		}
-		for i := 0; i < 270; i++ {
-			va, vb, vc := z.Var(rand.Intn(64)+1), z.Var(rand.Intn(64)+1), z.Var(rand.Intn(64)+1)
-			ma := va.Pos()
-			if rand.Intn(2) == 1 {
-				ma = ma.Not()
-			}
-			mb := vb.Pos()
-			if rand.Intn(2) == 1 {
-				mb = mb.Not()
-			}
-			mc := vc.Pos()
-			if rand.Intn(2) == 1 {
-				mc = mc.Not()
-			}
-			s0.Add(ma)
-			s0.Add(mb)
-			s0.Add(mc)
-			s0.Add(0)
-
-			s1.Add(ma)
-			s1.Add(mb)
-			s1.Add(mc)
-			s1.Add(0)
-		}
-		if n := s0.Simplify(); n != 0 {
-			t.Errorf("simplify gave %d\n", n)
-		}
-		a, b := s0.Solve(), s1.Solve()
-		if a != b {
-			t.Errorf("something went wrong %d,%d\n", a, b)
-		}
-		//t.Logf("%d ?= %d\n", a, b)
 	}
 }

--- a/inter/s.go
+++ b/inter/s.go
@@ -3,20 +3,25 @@
 
 package inter
 
-import "github.com/irifrance/gini/z"
+import (
+	"time"
+
+	"github.com/irifrance/gini/z"
+)
 
 // Interface Solveable encapsulates a decision
 // procedure which may run for a long time.
 //
-// Solve returns
+// Solve/Try returns
 //
 //  1  If the problem is SAT
-//  0  If the problem is undetermined
+//  0  If the problem is undetermined (Try only)
 //  -1 If the problem is UNSAT
 //
 // These error codes are used throughout gini.
 type Solvable interface {
 	Solve() int
+	Try(dur time.Duration) int
 }
 
 // Interface GoSolvable encapsulates a handle

--- a/internal/xo/cdb.go
+++ b/internal/xo/cdb.go
@@ -24,7 +24,8 @@ type Cdb struct {
 	Added   []z.C
 	Learnts []z.C
 
-	Tracer Tracer
+	Tracer     Tracer
+	checkModel bool
 
 	// for multi-scheduling gc frequency
 	gc *Cgc
@@ -46,15 +47,16 @@ func NewCdb(v *Vars, capHint int) *Cdb {
 		capHint = 3
 	}
 	clss := &Cdb{
-		Vars:    v,
-		CDat:    *NewCDat(capHint * 5),
-		AddLits: make([]z.Lit, 0, 24),
-		AddVals: make([]int8, v.Top),
-		Bot:     CNull,
-		Added:   make([]z.C, 0, capHint/3),
-		Learnts: make([]z.C, 0, capHint-capHint/3),
-		Tracer:  nil,
-		gc:      NewCgc()}
+		Vars:       v,
+		CDat:       *NewCDat(capHint * 5),
+		AddLits:    make([]z.Lit, 0, 24),
+		AddVals:    make([]int8, v.Top),
+		Bot:        CNull,
+		Added:      make([]z.C, 0, capHint/3),
+		Learnts:    make([]z.C, 0, capHint-capHint/3),
+		Tracer:     nil,
+		gc:         NewCgc(),
+		checkModel: true}
 	return clss
 }
 
@@ -409,6 +411,9 @@ func (c *Cdb) CheckWatches() []error {
 
 // by default, called when sat as a sanity check.
 func (c *Cdb) CheckModel() []error {
+	if !c.checkModel {
+		return nil
+	}
 	if c.Active != nil {
 		// deactivations and simplificaations remove Added clauses, which are unlinked
 		// until sufficiently large to compact.  compaction
@@ -453,6 +458,7 @@ func (c *Cdb) CopyWith(ov *Vars) *Cdb {
 	copy(other.Learnts, c.Learnts)
 	c.CDat.CopyTo(&other.CDat)
 	other.gc = c.gc.Copy()
+	other.checkModel = c.checkModel
 	return other
 }
 

--- a/internal/xo/phases.go
+++ b/internal/xo/phases.go
@@ -1,0 +1,43 @@
+package xo
+
+import "github.com/irifrance/gini/z"
+
+type phases z.Var
+
+func (p phases) init(s *S) phases {
+	if s.Vars.Max == z.Var(p) {
+		return p
+	}
+	M := s.Vars.Max
+	N := 2*M + 2
+	counts := make([]uint64, N)
+	L := uint64(16)
+	D := s.Cdb.CDat.D
+	for _, p := range s.Cdb.Added {
+		hd := Chd(D[p-1])
+		sz := uint64(hd.Size())
+		if sz >= L {
+			continue
+		}
+		var m z.Lit
+		q := p
+		for uint32(q-p) < uint32(sz) {
+			m = D[q]
+			if m == z.LitNull {
+				break
+			}
+			counts[m] += 1 << (L - sz)
+			q++
+		}
+	}
+	cache := s.Guess.cache
+	for i := z.Var(1); i <= M; i++ {
+		m, n := i.Pos(), i.Neg()
+		if counts[m] > counts[n] {
+			cache[i] = 1
+		} else {
+			cache[i] = -1
+		}
+	}
+	return phases(M)
+}

--- a/internal/xo/s.go
+++ b/internal/xo/s.go
@@ -275,18 +275,18 @@ func (s *S) Solve() int {
 		// guess
 		m := guess.Guess(vars.Vals)
 		if m == z.LitNull {
-			if false {
-				errs := cdb.CheckModel()
-				if len(errs) != 0 {
-					for _, e := range errs {
-						log.Println(e)
-					}
-					log.Println(s.Vars)
-					log.Println(s.Trail)
-
-					log.Printf("%p %p internal error: sat model\n", s, s.control)
-
+			errs := cdb.CheckModel()
+			if s.Active != nil {
+				s.Cdb.checkModel = false
+			}
+			if len(errs) != 0 {
+				for _, e := range errs {
+					log.Println(e)
 				}
+				log.Println(s.Vars)
+				log.Println(s.Trail)
+
+				log.Printf("%p %p internal error: sat model\n", s, s.control)
 			}
 			s.stSat++
 			// don't do this, we store the model returned to the user
@@ -504,6 +504,7 @@ func (s *S) Add(m z.Lit) {
 	s.ensureLitCap(m)
 	if m == z.LitNull {
 		s.ensure0()
+		s.Cdb.checkModel = true
 	}
 	loc, u := s.Cdb.Add(m)
 	if u != z.LitNull {

--- a/internal/xo/s.go
+++ b/internal/xo/s.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/irifrance/gini/dimacs"
 	"github.com/irifrance/gini/inter"
@@ -49,10 +50,13 @@ type S struct {
 	assumptLevel int
 	assumes      []z.Lit // only last set of requested assumptions before solve/test.
 	failed       []z.Lit
+	phases       phases
 
 	// Control
 	control          *Ctl
 	restartStopwatch int
+	startTime        time.Time
+	deadline         time.Time // synchronous (no pause)
 
 	// Stats (each object has its own, read by ReadStats())
 	stRestarts  int64
@@ -123,6 +127,8 @@ func NewSCdb(cdb *Cdb) *S {
 		return st
 	}
 	s.control.xo = s
+	s.startTime = time.Now()
+	s.deadline = s.startTime
 	return s
 }
 
@@ -139,6 +145,7 @@ func (s *S) Copy() *S {
 		other.Active = s.Active.Copy()
 		other.Cdb.Active = other.Active
 	}
+	other.phases = s.phases
 	luby := NewLuby()
 	*luby = *(s.luby)
 	other.luby = luby
@@ -158,6 +165,8 @@ func (s *S) Copy() *S {
 		other.ReadStats(st)
 		return st
 	}
+	other.startTime = s.startTime
+	other.deadline = s.deadline
 	return other
 }
 
@@ -178,6 +187,12 @@ func (s *S) String() string {
 	s.rmu.Lock()
 	defer s.rmu.Unlock()
 	return fmt.Sprintf("<xo@%d>", s.Trail.Level)
+}
+
+func (s *S) Try(dur time.Duration) int {
+	s.startTime = time.Now()
+	s.deadline = s.startTime.Add(dur)
+	return s.Solve()
 }
 
 // Method Solve solves the problem added to the solver under
@@ -237,6 +252,9 @@ func (s *S) Solve() int {
 			nxtTick += PropTick
 			tick++
 			if tick%CancelTicks == 0 {
+				if s.deadline != s.startTime && time.Until(s.deadline) <= 0 {
+					return 0
+				}
 				if !s.control.Tick() {
 					s.stEnded++
 					trail.Back(s.endTestLevel)
@@ -257,16 +275,18 @@ func (s *S) Solve() int {
 		// guess
 		m := guess.Guess(vars.Vals)
 		if m == z.LitNull {
-			errs := cdb.CheckModel()
-			if len(errs) != 0 {
-				for _, e := range errs {
-					log.Println(e)
+			if false {
+				errs := cdb.CheckModel()
+				if len(errs) != 0 {
+					for _, e := range errs {
+						log.Println(e)
+					}
+					log.Println(s.Vars)
+					log.Println(s.Trail)
+
+					log.Printf("%p %p internal error: sat model\n", s, s.control)
+
 				}
-				log.Println(s.Vars)
-				log.Println(s.Trail)
-
-				log.Printf("%p %p internal error: sat model\n", s, s.control)
-
 			}
 			s.stSat++
 			// don't do this, we store the model returned to the user
@@ -610,7 +630,7 @@ func (s *S) solveInit() int {
 	//log.Printf("%s\n", s.Vars)
 
 	// initialize phase
-	s.phaseInit()
+	s.phases = s.phases.init(s)
 	return 0
 }
 
@@ -683,42 +703,6 @@ func (s *S) makeAssumptions() int {
 		}
 	}
 	return 0
-}
-
-// TBD: make this understand solved clauses
-// and assumptions.
-func (s *S) phaseInit() {
-	M := s.Vars.Max
-	N := 2*M + 2
-	L := uint64(16)
-	counts := make([]uint64, N, N)
-	D := s.Cdb.CDat.D
-	for _, p := range s.Cdb.Added {
-		hd := Chd(D[p-1])
-		sz := uint64(hd.Size())
-		if sz >= L {
-			continue
-		}
-		var m z.Lit
-		q := p
-		for uint32(q-p) < uint32(sz) {
-			m = D[q]
-			if m == z.LitNull {
-				break
-			}
-			counts[m] += 1 << (L - sz)
-			q++
-		}
-	}
-	cache := s.Guess.cache
-	for i := z.Var(1); i <= M; i++ {
-		m, n := i.Pos(), i.Neg()
-		if counts[m] > counts[n] {
-			cache[i] = 1
-		} else {
-			cache[i] = -1
-		}
-	}
 }
 
 func (s *S) final(ms []z.Lit) {

--- a/sv.go
+++ b/sv.go
@@ -4,6 +4,8 @@
 package gini
 
 import (
+	"time"
+
 	"github.com/irifrance/gini/inter"
 	"github.com/irifrance/gini/z"
 )
@@ -65,6 +67,10 @@ func (w *svWrap) Value(m z.Lit) bool {
 
 func (w *svWrap) Solve() int {
 	return w.S.Solve()
+}
+
+func (w *svWrap) Try(dur time.Duration) int {
+	return w.S.Try(dur)
 }
 
 func (w *svWrap) GoSolve() inter.Solve {


### PR DESCRIPTION
This PR improves performance of incremental usage in settings where a significant number of the queries are very easy to solve.

This is done by
1. Adding a `Try(dur time.Duration)` method to inter.S which allows timeouts without running in a separate goroutine (profiling showed runtime.mstart was expensive with GoSolve()).
1. Making phase initialisation only occur when the number of variables has increased.
1. Only checking sat results after a solve against the clause DB when 
  - activation literals are in use; and
  - no clauses have been added since the last check (added, not "activated")
